### PR TITLE
[curl-vs-wget] Replace remaining period with colon

### DIFF
--- a/curl-vs-wget.md
+++ b/curl-vs-wget.md
@@ -30,7 +30,7 @@ problems or have improvements.
   internally. It is also slightly harder to make a library than a "mere"
   command line tool.
 
-- *pipes*. curl works more like the traditional Unix cat command, it sends
+- *pipes*: curl works more like the traditional Unix cat command, it sends
   more stuff to stdout, and reads more from stdin in a "everything is a pipe"
   manner. Wget is more like cp, using the same analogue.
 


### PR DESCRIPTION
In commit 0651de5 [1], I forgot to replace remaining period with colon
punctuation. This happened because in that line, I made two changes, fix
spell of Unix and punctuation; after committing spell correct [2], I
forgot to reapply punctuation change, sorry about that.

[1]: 0651de510ff0f49d942613af4b1661c054c4c202
[2]: c0ca138dccf59b683901ca56fc06b1a4208c6867